### PR TITLE
fix for repurposing with crs variable

### DIFF
--- a/src/qa4sm_preprocessing/reading/imagebase.py
+++ b/src/qa4sm_preprocessing/reading/imagebase.py
@@ -140,9 +140,7 @@ class ImageReaderBase(ReaderBase):
     @abstractmethod
     def _read_block(
         self, start: datetime.datetime, end: datetime.datetime
-    ) -> Dict[
-        str, Union[np.ndarray, dask.array.core.Array]
-    ]:  # pragma: no cover
+    ) -> Dict[str, Union[np.ndarray, dask.array.core.Array]]:  # pragma: no cover
         """
         Reads multiple images of a dataset as a numpy/dask array.
 
@@ -231,8 +229,7 @@ class ImageReaderBase(ReaderBase):
         coords = self.get_coords(times)
         dims = self.get_dims()
         arrays = {
-            name: (dims, data, array_attrs[name])
-            for name, data in block_dict.items()
+            name: (dims, data, array_attrs[name]) for name, data in block_dict.items()
         }
         block = xr.Dataset(arrays, coords=coords, attrs=self.global_attrs)
 
@@ -261,9 +258,7 @@ class ImageReaderBase(ReaderBase):
             )
         return block
 
-    def read(
-        self, timestamp: Union[datetime.datetime, str], **kwargs
-    ) -> Image:
+    def read(self, timestamp: Union[datetime.datetime, str], **kwargs) -> Image:
         """
         Read a single image at a given timestamp. Raises `ReaderError` if
         timestamp is not available in the dataset.
@@ -287,24 +282,38 @@ class ImageReaderBase(ReaderBase):
             timestamp = mkdate(timestamp)
 
         if timestamp not in self.timestamps:  # pragma: no cover
-            raise ReaderError(
-                f"Timestamp {timestamp} is not available in the dataset!"
-            )
+            raise ReaderError(f"Timestamp {timestamp} is not available in the dataset!")
 
-        img = self.read_block(
-            timestamp, timestamp, _apply_landmask_bbox=False
-        ).isel({self.timename: 0})
+        img = self.read_block(timestamp, timestamp, _apply_landmask_bbox=False).isel(
+            {self.timename: 0}
+        )
         img = self._stack(img)
+
+        if "parameter" in kwargs:
+            varnames = kwargs["parameter"]
+        else:
+            varnames = self.varnames
+
         data = {}
-        for varname in self.varnames:
+        for varname in varnames:
             var = img[varname].values
             if len(var) == len(self.grid.activegpis):
                 data[varname] = var
             else:
                 data[varname] = var[self.grid.activegpis]
-        metadata = {
-            varname: img[varname].attrs.copy() for varname in self.varnames
-        }
+        metadata = {varname: img[varname].attrs.copy() for varname in varnames}
+
+        # # the crs variable can sometimes grow very large in size during
+        # # repurposing, so we might want to delete it
+        # if (
+        #     hasattr(self, "drop_crs")
+        #     and self.drop_crs
+        #     and "crs" in data
+        #     and data["crs"].dtype.type is np.string_
+        # ):
+        #     del data["crs"]
+        #     del metadata["crs"]
+
         img = Image(
             self.grid.arrlon,
             self.grid.arrlat,
@@ -330,6 +339,7 @@ class ImageReaderBase(ReaderBase):
         end: Union[datetime.datetime, str] = None,
         overwrite: bool = False,
         memory: float = 2,
+        drop_crs: bool = True,
         **reader_kwargs,
     ):
         """
@@ -346,6 +356,11 @@ class ImageReaderBase(ReaderBase):
         overwrite: bool, optional (default: False)
             Whether to overwrite existing directories. If set to False, the
             function will return a reader for the existing directory.
+        drop_crs : bool, optional (default: True)
+            Some datasets have coordinate reference system info attached as a
+            string variable. During repurposing, this can strongly grow in
+            size. Therefore, by default, if a variable called "crs" is
+            encountered that has a string dtype, it is dropped.
         **reader_kwargs: additional keyword arguments for GriddedNcOrthoMultiTs
 
         Returns
@@ -357,12 +372,20 @@ class ImageReaderBase(ReaderBase):
         start, end = self._validate_start_end(start, end)
         if (outpath / "grid.nc").exists() and overwrite:
             shutil.rmtree(outpath)
-        if not (
-            outpath / "grid.nc"
-        ).exists():  # if overwrite=True, it was deleted now
+        if not (outpath / "grid.nc").exists():  # if overwrite=True, it was deleted now
             outpath.mkdir(exist_ok=True, parents=True)
             testimg = self._testimg()
-            array_attrs = {v: testimg[v].attrs.copy() for v in self.varnames}
+
+            if (
+                drop_crs
+                and "crs" in self.varnames
+                and testimg.crs.dtype.type is np.string_
+            ):
+                varnames = [v for v in self.varnames if v != "crs"]
+            else:
+                varnames = self.varnames
+
+            array_attrs = {v: testimg[v].attrs.copy() for v in varnames}
             n = nimages_for_memory(testimg, memory)
             logging.info(f"Reading {n} images at once.")
             if hasattr(self, "use_tqdm"):  # pragma: no branch
@@ -373,9 +396,10 @@ class ImageReaderBase(ReaderBase):
                 str(outpath),
                 start,
                 end,
+                input_kwargs={"parameter": varnames},
+                ts_attributes=array_attrs,
                 cellsize_lat=self.cellsize,
                 cellsize_lon=self.cellsize,
-                ts_attributes=array_attrs,
                 global_attr=self.global_attrs,
                 zlib=True,
                 imgbuffer=n,

--- a/src/qa4sm_preprocessing/reading/imagebase.py
+++ b/src/qa4sm_preprocessing/reading/imagebase.py
@@ -303,17 +303,6 @@ class ImageReaderBase(ReaderBase):
                 data[varname] = var[self.grid.activegpis]
         metadata = {varname: img[varname].attrs.copy() for varname in varnames}
 
-        # # the crs variable can sometimes grow very large in size during
-        # # repurposing, so we might want to delete it
-        # if (
-        #     hasattr(self, "drop_crs")
-        #     and self.drop_crs
-        #     and "crs" in data
-        #     and data["crs"].dtype.type is np.string_
-        # ):
-        #     del data["crs"]
-        #     del metadata["crs"]
-
         img = Image(
             self.grid.arrlon,
             self.grid.arrlat,

--- a/src/qa4sm_preprocessing/utils.py
+++ b/src/qa4sm_preprocessing/utils.py
@@ -63,10 +63,10 @@ def make_csv_dataset(
 
     for gpi, (ts, lat, lon) in enumerate(zip(timeseries, lats, lons)):
         if grid is not None:
-            nearest_gpi, _ = grid.find_k_nearest_gpi(
+            nearest_gpi, dist = grid.find_k_nearest_gpi(
                 lon, lat, k=1, max_dist=radius * 1000
             )
-            if len(nearest_gpi) == 0:
+            if dist == np.inf:
                 continue
         write_timeseries(ts, gpi, lat, lon, name, outpath)
     if metadata is not None:
@@ -121,10 +121,10 @@ def make_gridded_contiguous_ragged_dataset(
         newgpis = []
         newts = []
         for gpi, (ts, lat, lon) in enumerate(zip(timeseries, lats, lons)):
-            nearest_gpi, _ = grid.find_k_nearest_gpi(
+            nearest_gpi, dist = grid.find_k_nearest_gpi(
                 lon, lat, k=1, max_dist=radius * 1000
             )
-            if len(nearest_gpi) == 0:
+            if dist == np.inf:
                 continue
             newlats.append(lat)
             newlons.append(lon)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ here = Path(__file__).resolve().parent
 
 def pytest_configure():
     pytest.test_data_path = here / "test-data" / "preprocessing"
+    pytest.test_data_user_upload_path = here / "test-data" / "user_data"
 
 
 @pytest.fixture

--- a/tests/test_reading/test_stack.py
+++ b/tests/test_reading/test_stack.py
@@ -128,3 +128,9 @@ def test_dimension_orders(synthetic_test_args):
     assert reader.timename == "time"
     assert reader.get_dims() == expected_dims
     validate_reader(reader, ds)
+
+
+def test_small_cellsize(synthetic_test_args):
+    ds, kwargs = synthetic_test_args
+    reader = StackImageReader(ds, **kwargs, cellsize=0.01)
+    assert len(np.unique(reader.grid.activearrcell)) > 1

--- a/tests/test_reading/test_user_upload.py
+++ b/tests/test_reading/test_user_upload.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 import yaml
+import xarray as xr
 import zipfile
 
 from qa4sm_preprocessing.reading import (
@@ -15,6 +16,8 @@ from qa4sm_preprocessing.utils import (
     make_gridded_contiguous_ragged_dataset,
     preprocess_user_data,
 )
+
+from pytest import test_data_user_upload_path
 
 
 def make_test_timeseries(lats=[12, 34, 56], lons=[0.1, 2.3, 4.5]):
@@ -263,3 +266,14 @@ def test_contiguous_ragged_pipeline_only_ismn(test_output_path):
     np.testing.assert_equal(np.sort(grid.activearrlat), np.sort(close_lats))
     np.testing.assert_equal(np.sort(grid.activearrlon), np.sort(close_lons))
     np.testing.assert_equal(np.sort(grid.activegpis), np.sort(expected_gpis))
+
+
+def test_hr_cgls_preprocessing(test_output_path):
+    orig = xr.open_dataset(test_data_user_upload_path / "teststack_hr_cgls_small.nc")
+    assert "crs" in orig
+
+    reader = preprocess_user_data(
+        test_data_user_upload_path / "teststack_hr_cgls_small.nc",
+        test_output_path / "pynetcf"
+    )
+    assert "crs" not in reader.variable_description().keys()


### PR DESCRIPTION
- adds a keyword argument `drop_crs` to `.repurpose()` which drops string crs variables before reshuffling, because they can be very large in size
- fixes for new pygeogrids version
- tests + test-data